### PR TITLE
updated the get rds function to take the base API URL.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,7 @@ License: file LICENSE
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.0
+Imports: curl
 Suggests: knitr, rmarkdown, ggplot2, scales, gridExtra
 VignetteBuilder: knitr
 

--- a/R/functions.R
+++ b/R/functions.R
@@ -1,40 +1,27 @@
 #' Get RDS Server
 #'
-#' This function uses the provided host, port, and protocol to build up an RDS server. This will create the base
-#' api paths that the server uses as well as pulling basis information about the server.
+#' This function uses the provided API URL to connect to a RDS server. Connecting to the server will 
+#' validate that this URL is correct and all the subsequent calls for catalogs, data products, metadata,
+#' or data will use this API URL as a base.
 #'
-#' @param host The host or domain name of the server
-#' @param port The port the RDS server is running on if needed. This is NULL by default.
-#' @param protocol The protocol to use in the call, http by default.
+#' @param apiUrl The RDS API URL of the RDS instance that is being accessed. 
 #' @import methods
 #' @keywords server
 #' @export
 #' @examples
-#' get.rds("http://dev.richdataservices.com")
-get.rds <- function(host,
-                    port = NULL,
-                    protocol = "http") {
+#' get.rds("http://dev.richdataservices.com/rds/api")
+get.rds <- function(apiUrl) {
   # Set up the URL of the server
-  baseUrl <- ""
+  baseUrl <- apiUrl
   
-  # if the user has not included the protocol, we will append it now
-    if (!startsWith(host, "http")) {
-    baseUrl <- protocol
-    if (!endsWith(protocol, "://")) {
-      baseUrl <- paste(baseUrl, "://", sep = "", collapse = NULL)
-    }
+  # if the user has a trailing / we will remove it.
+  if (endsWith(baseUrl, "/")) {
+    baseUrl <- substr(baseUrl, 0, nchar(baseUrl)-1)
   }
-  
-  # add the domain to the url
-  baseUrl <- paste(baseUrl, host, sep = "", collapse = NULL)
-  if (!is.null(port)) {
-    baseUrl <- paste(baseUrl, ":", port, sep = "", collapse = NULL)
-  }
-  baseUrl <- paste(baseUrl, "/rds", sep = "", collapse = NULL)
   
   # Get the server information
   serverInfo <-
-    jsonlite::fromJSON(paste(baseUrl, "/api/server/info", sep = "", collapse = NULL))
+    jsonlite::fromJSON(paste(baseUrl, "/server/info", sep = "", collapse = NULL))
   serverName <- serverInfo[[1]][1]
   serverVersion <- serverInfo[[2]][1]
   
@@ -42,7 +29,7 @@ get.rds <- function(host,
   disclaimer <-
     tryCatch(
       jsonlite::fromJSON(paste(
-        baseUrl, "/api/server/disclaimer", sep = "", collapse = NULL
+        baseUrl, "/server/disclaimer", sep = "", collapse = NULL
       )),
       error = function(e) {
         disclaimer <- ""

--- a/R/methods.R
+++ b/R/methods.R
@@ -19,7 +19,7 @@ setMethod("getCatalogs", signature("rds.server"), function(server) {
   # Query the server for all the catalogs
   catalogsUrl <-
     paste(server@baseUrl,
-          "/api/catalog",
+          "/catalog",
           sep = "",
           collapse = NULL)
   response <- jsonlite::fromJSON(catalogsUrl)
@@ -69,7 +69,7 @@ setMethod("getCatalog", signature("rds.server", "character"), function(server, c
   tryCatch({
     catalogUrl <- paste(
       server@baseUrl,
-      "/api/catalog/",
+      "/catalog/",
       catalogId,
       sep = "",
       collapse = NULL
@@ -130,7 +130,7 @@ setMethod("getDataProducts", signature("rds.catalog"), function(catalog) {
   server <- catalog@server
   dataProductsUrl <-
     paste(server@baseUrl,
-          "/api/catalog/",
+          "/catalog/",
           catalog@id,
           sep = "",
           collapse = NULL)
@@ -188,7 +188,7 @@ setMethod("getDataProduct", signature("rds.catalog", "character"), function(cata
   tryCatch({
     dataProductUrl <- paste(
       server@baseUrl,
-      "/api/catalog/",
+      "/catalog/",
       catalog@id,
       "/",
       dataProductId,
@@ -283,7 +283,7 @@ setMethod("getVariables", signature("rds.dataProduct"), function(dataProduct,
   # Set up the get request
   variablesUrl <- paste(
     rds@baseUrl,
-    "/api/catalog/",
+    "/catalog/",
     catalog@id,
     "/",
     dataProduct@id,
@@ -361,7 +361,7 @@ setMethod("getVariable", signature("rds.dataProduct", "character"), function(dat
   tryCatch({
     variableUrl <- paste(
       server@baseUrl,
-      "/api/catalog/",
+      "/catalog/",
       catalog@id,
       "/",
       dataProduct@id,
@@ -512,7 +512,7 @@ setMethod("getClassifications", signature("rds.dataProduct"), function(dataProdu
   request <-
     paste(
       rds@baseUrl,
-      "/api/catalog/",
+      "/catalog/",
       catalog@id,
       "/",
       dataProduct@id,
@@ -589,7 +589,7 @@ setMethod("getClassification", signature("rds.dataProduct", "character"), functi
   request <-
     paste(
       rds@baseUrl,
-      "/api/catalog/",
+      "/catalog/",
       catalog@id,
       "/",
       dataProduct@id,
@@ -610,7 +610,7 @@ setMethod("getClassification", signature("rds.dataProduct", "character"), functi
     codeRequest <-
       paste(
         rds@baseUrl,
-        "/api/catalog/",
+        "/catalog/",
         catalog@id,
         "/",
         dataProduct@id,
@@ -732,7 +732,7 @@ setMethod("rds.select", signature("rds.dataProduct"), function(dataProduct,
     # Build the select query
     select <- paste(
       rds@baseUrl,
-      "/api/query/",
+      "/query/",
       catalog@id,
       "/",
       dataProduct@id,
@@ -999,7 +999,7 @@ setMethod("rds.tabulate", signature("rds.dataProduct", "character"), function(da
   tabulate <-
     paste(
       rds@baseUrl,
-      "/api/query/",
+      "/query/",
       catalog@id,
       "/",
       dataProduct@id,

--- a/man/get.rds.Rd
+++ b/man/get.rds.Rd
@@ -4,20 +4,17 @@
 \alias{get.rds}
 \title{Get RDS Server}
 \usage{
-get.rds(host, port = NULL, protocol = "http")
+get.rds(apiUrl)
 }
 \arguments{
-\item{host}{The host or domain name of the server}
-
-\item{port}{The port the RDS server is running on if needed. This is NULL by default.}
-
-\item{protocol}{The protocol to use in the call, http by default.}
+\item{apiUrl}{The RDS API URL of the RDS instance that is being accessed.}
 }
 \description{
-This function uses the provided host, port, and protocol to build up an RDS server. This will create the base
-api paths that the server uses as well as pulling basis information about the server.
+This function uses the provided API URL to connect to a RDS server. Connecting to the server will 
+validate that this URL is correct and all the subsequent calls for catalogs, data products, metadata,
+or data will use this API URL as a base.
 }
 \examples{
-get.rds("http://dev.richdataservices.com")
+get.rds("http://dev.richdataservices.com/rds/api")
 }
 \keyword{server}

--- a/vignettes/rds.catalog.rmd
+++ b/vignettes/rds.catalog.rmd
@@ -23,11 +23,11 @@ library("knitr")
 Catalogs in RDS are simply collections of data products. A data product is the object in RDS that holds data and any documentation or metadata that surrounds the data. The catalog contains a list of data products and we can get all of them or a single product if desired.
 
 ```{r}
-# set up the host / domain name of the RDS instance
-host = "http://covid19.richdataservices.com"
+# set up the base API URL
+apiUrl = "http://covid19.richdataservices.com/rds/api"
 
 # connect to the server
-rds <- get.rds(host)
+rds <- get.rds(apiUrl)
 
 # get a catalog
 census <- rds.r::getCatalog(rds, "uscensus")

--- a/vignettes/rds.select.Rmd
+++ b/vignettes/rds.select.Rmd
@@ -33,7 +33,8 @@ R users would typically be an exception to this rule. The R library is designed 
 The first thing we need to do is set up a connection to the RDS server and get the data product we want to use.
 
 ```{r }
-rds <- get.rds("http://covid19.richdataservices.com")
+# provide the api URL to get the server
+rds <- get.rds("http://covid19.richdataservices.com/rds/api")
 catalog <- rds.r::getCatalog(rds, "uscensus")
 dataProduct <- rds.r::getDataProduct(catalog, "census2010-hp")
 ```

--- a/vignettes/rds.server.rmd
+++ b/vignettes/rds.server.rmd
@@ -22,11 +22,11 @@ library("knitr")
 
 Setting up the connection to the RDS server is the starting point to interacting with the RDS API through R. It provides an entry point to the API and will facilitate the handling of API calls for catalogs and data products. 
 ```{r}
-# set up the host / domain name of the RDS instance
-host = "http://covid19.richdataservices.com"
+# set up the base API URL
+apiUrl = "http://covid19.richdataservices.com/rds/api"
 
 # connect to the server
-rds <- get.rds(host)
+rds <- get.rds(apiUrl)
 ```
 
 The server will come with some basic information about it.

--- a/vignettes/rds.tabulate.Rmd
+++ b/vignettes/rds.tabulate.Rmd
@@ -30,7 +30,8 @@ The tabulate method allows tabulations to be created by specifying the dimension
 The first thing we need to do is set up a connection to the RDS server and get the data product we want to use, in this case we will use a subset of the U.S. 2010 Census PUMS files, containing DC, DE, MD, and VA.
 
 ```{r }
-rds <- get.rds("http://covid19.richdataservices.com")
+# provide the api URL to get the server
+rds <- get.rds("http://covid19.richdataservices.com/rds/api")
 catalog <- rds.r::getCatalog(rds, "uscensus")
 dataProduct <- rds.r::getDataProduct(catalog, "census2010-hp")
 ```


### PR DESCRIPTION
Having the user provide the base API URL rather than trying to build this up for them will allow for greater configuration when the api may be proxied to and it is inappropriate to assume it is under the /rds/api path after the domain.